### PR TITLE
Add explicit play action on Safari only

### DIFF
--- a/bach.js
+++ b/bach.js
@@ -38,6 +38,10 @@ var player; // The web player
 
 window.bach = bach = {};
 
+bach.start = function() {
+  player && player.play();
+};
+
 bach.stop = function() {
     player && player.stop();
 };
@@ -74,7 +78,7 @@ bach.process = function process(data) {
     }
 
     mod = 0;
-
+    
     for (i=0; i<notes; i++) {
         messages = [];
 
@@ -84,7 +88,7 @@ bach.process = function process(data) {
         }
         real = real_chord(i);
         var sa = 0, st = 0, sb = 0, at = 0, ab = 0, tb = 0;
-
+        
         switch (roman(i)) {
             case "Ic":
                 if (i < notes-1 && chord[i] == 1 && next_chord() != 5 && next_chord() != 9)
@@ -153,7 +157,6 @@ bach.process = function process(data) {
     }
 
     player = conductor.finish();
-    player.play();
 }
 
 function real_chord(c) {

--- a/index.html
+++ b/index.html
@@ -38,6 +38,14 @@
             font-size: 150%;
         }
     }
+    
+    #play {
+      display: block;
+      margin: -2em 0 0 -1em;
+      position: relative;
+      text-align: center;
+      top: 110px;
+    }
 
     #stop {
         position: absolute;

--- a/player.js
+++ b/player.js
@@ -1,3 +1,11 @@
+window.is_safari = ( typeof window.webkitAudioContext === "function" );
+
+bachStart = function() {
+  document.getElementById('output').innerHTML = "";
+  document.getElementById('stop').style.display = 'block';
+  bach.start()
+};
+
 bachStop = function() {
     bach.stop();
     document.getElementById('stop').style.display = 'none';
@@ -6,13 +14,16 @@ bachStop = function() {
 bachLoad = function(file) {
     bachStop();
     var oput = document.getElementById('output');
-    oput.innerHTML = '';
     oput.style.height = oput.offsetHeight + 'px';
-    document.getElementById('stop').style.display = 'block';
     fetch(file).then(function(res) {
         res.text().then(function(text) {
             data = text.split("\n");
             bach.process(data);
+            if ( window.is_safari ) {
+              oput.innerHTML = '<li id="play">Ready<br /><a href="javascript:bachStart();">PLAY</a></li>'
+            } else {
+              bachStart();
+            }
         });
     });
 };


### PR DESCRIPTION
This PR adds a new `bachStart` function which is called automatically on all browsers except Safari where it is instead attached to a link displayed to the user when the player is ready.

This should fix #1. Not tested in mobile Safari yet.